### PR TITLE
fix voltaire github link

### DIFF
--- a/docs/bundler/0-intro.md
+++ b/docs/bundler/0-intro.md
@@ -7,7 +7,7 @@ image: "/img/erc4337-bundler.png"
 # Introduction
 Voltaire is a new modular, developer-friendly and lighting-fast Python Bundler for Ethereum EIP-4337 Account Abstraction. Voltaire is a fully open-source project designed to operate within the peer-to-peer mempool of UserOperations, facilitating the inclusion of transactions on-chain more quickly and efficiently.
 
-The code is available for free on [Github](https://candidelabs.com/voltaire) under a permissive license for anyone to use without any strings attached. We encourage the community to fork it, contribute with docs, issues, pull requests, questions, or even try to break it.
+The code is available for free on [Github](https://github.com/candidelabs/voltaire) under a permissive license for anyone to use without any strings attached. We encourage the community to fork it, contribute with docs, issues, pull requests, questions, or even try to break it.
 <p align="center">
   <img src="/img/erc4337-bundler.png" />
 </p>


### PR DESCRIPTION
The redirect link is broken, changed to github link.